### PR TITLE
Fix positive percentage indicators missing plus sign

### DIFF
--- a/components/ui/PriceIndicator.tsx
+++ b/components/ui/PriceIndicator.tsx
@@ -51,8 +51,11 @@ export function PriceIndicator({
   const formatValue = () => {
     let formattedValue = String(value);
     
-    if (showSign && typeof value === 'number') {
-      formattedValue = `${value >= 0 ? '+' : ''}${value}`;
+    if (showSign) {
+      const numericValue = Number(value);
+      if (!Number.isNaN(numericValue)) {
+        formattedValue = `${numericValue >= 0 ? '+' : ''}${formattedValue}`;
+      }
     }
     
     return `${prefix}${formattedValue}${suffix}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Fixed `PriceIndicator` sign formatting so `showSign` works when `value` is a numeric string (the path used by `PercentageChange`).
- Kept behavior unchanged for non-numeric values; only numeric-like values now get `+`/`-` prefixes.

## Bug repro (before fix)
- Command used to render `PercentageChange` server-side:
  - `npx --yes tsx -e "import React from 'react'; import { renderToStaticMarkup } from 'react-dom/server'; import { PercentageChange } from './components/ui/PriceIndicator'; const html = renderToStaticMarkup(React.createElement(PercentageChange,{value:12.34,showSign:true})); console.log(html);"`
- Before this PR, output lacked plus sign for positive values:
  - `...>12.34%</div>`

## Validation (after fix)
- Same repro now outputs:
  - `...>+12.34%</div>`
- Negative values still output correctly:
  - `...>-12.34%</div>`
- Lint passes.
- Manual UI verification in running app confirms multiple positive percentages display with `+`.

## Walkthrough artifacts
[percentage_change_plus_sign_demo.mp4](https://cursor.com/agents/bc-f6002e9e-ac6c-40ea-8501-034d878c81c0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpercentage_change_plus_sign_demo.mp4)
[Positive percentage signs on home view](https://cursor.com/agents/bc-f6002e9e-ac6c-40ea-8501-034d878c81c0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpercentage_sign_positive_home.webp)
[Additional positive percentage sign evidence](https://cursor.com/agents/bc-f6002e9e-ac6c-40ea-8501-034d878c81c0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpercentage_sign_positive_home_2.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6002e9e-ac6c-40ea-8501-034d878c81c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6002e9e-ac6c-40ea-8501-034d878c81c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

